### PR TITLE
fix: fixed typings and security vulns

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,7 @@ const https = require('https');
 const parse = require('proto-parse');
 const snakeCase = require('snake-case');
 const { createInterfacesFromObject } = require('typescript-interface-generator');
+const { readFileSync, writeFileSync } = require('fs');
 
 const typeExamples = {
   uint64: 1,
@@ -46,7 +47,7 @@ getProto().then(rawProto => {
   const enums = data.content.filter(i => i.type === 'enum');
   const dataContainer = [];
 
-  const defaultTypes = require('fs').readFileSync('defaultTypes.d.ts');
+  const defaultTypes = readFileSync('defaultTypes.d.ts');
   dataContainer.push(defaultTypes);
   
   messages.forEach(message => {
@@ -104,7 +105,7 @@ getProto().then(rawProto => {
     dataContainer.push(definitionString);
   });
 
-  require('fs').writeFileSync('index.d.ts', dataContainer.join('\n'));
+  writeFileSync('index.d.ts', dataContainer.join('\n'));
 
 });
 

--- a/defaultTypes.d.ts
+++ b/defaultTypes.d.ts
@@ -12,4 +12,5 @@ export type ApiObjectProperty =
   | number
   | string
   | string[]
-  | boolean;
+  | boolean
+  | undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,8 @@ export type ApiObjectProperty =
   | number
   | string
   | string[]
-  | boolean;
+  | boolean
+  | undefined;
 
 export interface Count extends ApiObject {
   count?: number;
@@ -1245,12 +1246,9 @@ export enum WebsiteCategoryEnum {
   WEBSITE_ANDROID = 12,
   WEBSITE_STEAM = 13,
   WEBSITE_REDDIT = 14,
-  WEBSITE_DISCORD = 15,
-  WEBSITE_GOOGLE_PLUS = 16,
-  WEBSITE_TUMBLR = 17,
-  WEBSITE_LINKEDIN = 18,
-  WEBSITE_PINTEREST = 19,
-  WEBSITE_SOUNDCLOUD = 20
+  WEBSITE_ITCH = 15,
+  WEBSITE_EPICGAMES = 16,
+  WEBSITE_GOG = 17
 }
 
 export enum CreditCategoryEnum {

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,9 +412,9 @@
       }
     },
     "fast-glob": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
-      "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
         "@nodelib/fs.stat": "^1.1.2",
@@ -489,9 +489,9 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -530,9 +530,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -578,9 +578,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -761,9 +761,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -794,9 +794,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -982,9 +982,9 @@
       }
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -1216,14 +1216,14 @@
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
     },
     "typescript-interface-generator": {
       "version": "0.0.6",
@@ -1239,35 +1239,14 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "universalify": {


### PR DESCRIPTION
d31b63c: Fixed security vulnerabilities. `npm install` was logging various security vulnerabilities to be fixed with `npm audit fix`:

```sh
$ npm i
npm WARN @igdb/types@0.0.9 No repository field.

added 162 packages from 115 contributors and audited 971 packages in 2.883s
found 15 high severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
```

---

c2c789f: Fixed typings. They were not able to be used in TS projects at all due to missing `| undefined` in the `ApiObjectProperty`. The only way to even use the typings was to add the `--skipLibCheck` option in TS which in itself is not recommended for TS projects.

That all said, it was a really easy fix and didn't even really change the typings all that much since the properties themselves were already marked as undefined, undefined was just missing as a potential index type.

For reference these kinds of errors were thrown (and many, many of them):

```ts
node_modules/@igdb/types/index.d.ts:1151:3 - error TS2411: Property 'url' of type 'string | undefined' is not assignable to string index type 'ApiObjectProperty'.

1151   url?: string;
       ~~~


Found 652 errors.
```

---

I also ran the build script for good measure, which properly updated the `index.d.ts`. The move of the `require('fs')` you'll see there is just a small cleanup thing.

Lastly I would greatly appreciate it if you guys could release v0.0.10 to NPM upon merging this PR so the fixed typings can be used in projects requiring NPM versions.